### PR TITLE
Add copy as to context (right click) menu

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "Copy to clipboard as HTML",
+        "caption": "Copy as HTML",
         "command": "sublime_highlight",
         "args": {
             "target": "clipboard",
@@ -8,7 +8,7 @@
         }
     },
     { 
-        "caption": "Copy to clipboard as RTF",
+        "caption": "Copy as RTF",
         "command": "sublime_highlight",
         "args": {
             "target": "clipboard",


### PR DESCRIPTION
I thought since you can right click to copy the selected text, intuitively you should also be able to copy as HTML/RTF the same way. Plus I think it is quicker then having to use the main menu system.
