### PR TITLE
Fixed alloc made twice that caused copy as RTF crashes on windows.

### DIFF
--- a/winclip/__init__.py
+++ b/winclip/__init__.py
@@ -70,7 +70,6 @@ def Put(data, format):
     else:
         hCd = ga(GHND, len(bytes(data)) + sizeof(c_wchar()))
 
-    hCd = ga(GHND, len(bytes(data)) + 2)
     pchData = gl(hCd)
 
     if format == CF_UNICODETEXT:


### PR DESCRIPTION
Should fix #32 #29 #22
