### PR TITLE
Bugfix for Issue #47 - Copy RTF To Clipboard fails

### DIFF
--- a/HighlightLib/winclip/__init__.py
+++ b/HighlightLib/winclip/__init__.py
@@ -49,8 +49,6 @@ def Paste(data, type='text', plaintext=None):
     elif type == 'html':
         Put(data, CF_HTML)
 
-    Put(plaintext, CF_TEXT)
-    Put(unicodetext, CF_UNICODETEXT)
     ccb()
 
 


### PR DESCRIPTION
Copying text as either RTF or HTML was throwing the following error:

_File "C:\Program Files\Sublime Text 3\sublime_plugin.py", line 543, in run_
    return self.run(edit, *_args)
  File "C:\Users\chrisg\AppData\Roaming\Sublime Text 3\Packages\Highlight\SublimeHighlight.py", line 143, in run
    winclip.Paste(pygmented, output_type, plaintext)
  File "C:\Users\chrisg\AppData\Roaming\Sublime Text 3\Packages\Highlight\HighlightLib\winclip__init__.py", line 47, in Paste
    Put(data, CF_RTF)
  File "C:\Users\chrisg\AppData\Roaming\Sublime Text 3\Packages\Highlight\HighlightLib\winclip__init__.py", line 68, in Put
    raise Exception('Failed to lock: %r' % code)
Exception: Failed to lock: 6*

After removing two extra put calls in the Paste function, this issue is resolved.
