### PR TITLE
Copy RTF To Clipboard fails - Second Commit

### DIFF
--- a/HighlightLib/winclip/__init__.py
+++ b/HighlightLib/winclip/__init__.py
@@ -45,7 +45,6 @@ def Paste(data, type='text', plaintext=None):
 
     if type == 'rtf':
         Put(data, CF_RTF)
-        Put(data, CF_RTFWO)
     elif type == 'html':
         Put(data, CF_HTML)
 


### PR DESCRIPTION
I have found another occurrence of this bug happening when you try to copy as html, followed by trying to copy as RTF. For whatever reason, the RTF Without Objects format throws an exception. Unless there is more insight onto the problem here, it appears removing it fixes the issue.
