### PR TITLE
Fix endswith error on Ubuntu (Python 3)

### DIFF
--- a/desktop/__init__.py
+++ b/desktop/__init__.py
@@ -135,7 +135,7 @@ def _is_xfce():
     # XFCE detection involves testing the output of a program.
 
     try:
-        return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().endswith(' = "xfce4"')
+        return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().endswith(b' = "xfce4"')
     except OSError:
         return 0
 


### PR DESCRIPTION
TypeError: endswith first arg must be bytes or a tuple of bytes, not str