### PR TITLE
Handle 'with BOM' UTF encodings.

### DIFF
--- a/SublimeHighlight.py
+++ b/SublimeHighlight.py
@@ -52,6 +52,12 @@ class SublimeHighlightCommand(sublime_plugin.TextCommand):
             encoding = 'utf-8'
         elif encoding == 'Western (Windows 1252)':
             encoding = 'windows-1252'
+        else:
+            i = encoding.find(' with BOM')
+
+            if i != -1:
+                encoding = encoding[:i]
+
         return encoding
 
     @property


### PR DESCRIPTION
I noticed that some Windows based files have encodings of 'UTF-8 with BOM', 'UTF-16 with BOM', etc. This handles those, otherwise the encoding fails.