### PR TITLE
more sensible open command for GNOME

### DIFF
--- a/HighlightLib/desktop/__init__.py
+++ b/HighlightLib/desktop/__init__.py
@@ -260,7 +260,7 @@ def open(url, desktop=None, wait=0):
         cmd = ["kfmclient", "exec", url]
 
     elif desktop_in_use == "GNOME":
-        cmd = ["gnome-open", url]
+        cmd = ["xdg-open", url]
 
     elif desktop_in_use == "XFCE":
         cmd = ["exo-open", url]


### PR DESCRIPTION
gnome-open is no longer included in modern GNOME by default. `xdg-open` or `gvfs-open` are better options. Here, `xdg-open` is preferred as it is platform independent.