### PR TITLE
Fixing Sublime Text 3 syntax detection

### DIFF
--- a/SublimeHighlight.py
+++ b/SublimeHighlight.py
@@ -72,7 +72,7 @@ class SublimeHighlightCommand(sublime_plugin.TextCommand):
         syntax = self.view.settings().get('syntax')
         if not syntax:
             return
-        match = re.match(r"Packages/.*/(.*?)\.tmLanguage$", syntax)
+        match = re.match(r"Packages/.*/(.*?)\.(?:tmLanguage|sublime-syntax)$", syntax)
         if not match:
             return
         try:


### PR DESCRIPTION
Sublime Text 3 [syntax files](https://www.sublimetext.com/docs/3/syntax.html) may end with `.sublime-syntax` or `.tmLanguage`, meaning `guess_lexer_from_syntax()` would almost never match.

For unsaved files (i.e. `view.file_name() == None`) this means `get_lexer()` almost always falls through to `pygments.lexers.guess_lexer()`  which has a questionable success rate for some languages.  For people who use lots of scratch files like myself, this can cause a bit of confusion.